### PR TITLE
automatically define commands defined in user's keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,45 @@
 # keystroke
 
-Define command from keystroke.
+Keymap from keystroke to keystroke in your `keymap.cson`.
 
-# example
+```coffeescript
+'atom-text-editor':
+  'ctrl-a': 'keystroke ctrl-e ctrl-p'
 
-config.cson
+'atom-text-editor.vim-mode-plus.normal-mode':
+  'space j': 'keystroke 5 j'
+  'space k': 'keystroke 5 k'
+```
+
+**RULE: Command name must start with `keystroke `**.
+
+# What is happening under the hood.
+
+- When `keymap.cson` was loaded, collect `keystroke ` prefixed commands from loaded keymaps.
+- Register these commands automatically.
+
+# Two way to reigster keystroke command
+
+For historical reason, there is two way to register keystroke commands.
+
+- [New and auto]: Automatically register keystroke commands from loaded user's keymaps.
+- [Old and manual]: Manually register keystroke commands from `keystroke.commands` configuration( older way ).
+
+## [New and auto] auto register via `keymap.cson`
+
+- `keymap.cson`
+
+```coffeescript
+'atom-text-editor':
+  'ctrl-cmd-c': 'keystroke ctrl-shift-w backspace'
+
+'atom-text-editor.vim-mode-plus.normal-mode':
+  'C': 'keystroke c i w'
+```
+
+## [Old and manual] manual register via `keystroke.commands`
+
+- `config.cson`
 
 ```coffeescript
 "*":
@@ -17,12 +52,12 @@ config.cson
       }
       {
         name: "change-inner-word"
-        keystroke: "c i w" # using vim-mode or vim-mode-plus keymap
+        keystroke: "c i w" # using vim-mode-plus keymap
       }
     ]
 ```
 
-keymap.cson
+- `keymap.cson`
 
 ```coffeescript
 'atom-text-editor':

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,44 +1,11 @@
 const {CompositeDisposable} = require("atom")
 const {dispatchKeystroke} = require("./utils")
 
-const Config = {
-  autoLoadCommandsFromUserKeymap: {
-    type: "boolean",
-    default: true,
-    dscription:
-      "When `true`, each time user-keymap loaded, automatically define the commands starts with `keymaps:auto:`.",
-  },
-  commands: {
-    type: "array",
-    default: [],
-    items: {
-      type: "object",
-      properties: {
-        name: {type: "string"},
-        keystroke: {type: "string"},
-        scope: {type: "string"},
-      },
-    },
-  },
-}
-
 module.exports = {
-  config: Config,
-
   activate() {
-    const userKeymapPath = atom.keymaps.getUserKeymapPath()
     this.subscriptions = new CompositeDisposable(
-      atom.config.observe("keystroke.commands", commandSpecs => this.registerCommands(commandSpecs)),
-      atom.config.observe("keystroke.autoLoadCommandsFromUserKeymap", enabled => {
-        if (this.userKeymapObserver) this.userKeymapObserver.dispose()
-        if (enabled) this.userKeymapObserver = this.observeUserKeymaps()
-      }),
-      atom.keymaps.onDidLoadUserKeymap(() => this.onKeymapLoaded()),
-      atom.keymaps.onDidReloadKeymap(({path}) => {
-        if (path === userKeymapPath) {
-          this.onKeymapLoaded()
-        }
-      })
+      atom.config.observe("keystroke.commands", commandSpecs => this.onConfigChange(commandSpecs)),
+      atom.config.observe("keystroke.autoLoadCommandsFromUserKeymap", enabled => this.toggleObserveUserKeymaps(enabled))
     )
   },
 
@@ -49,8 +16,12 @@ module.exports = {
     this.subscriptions.dispose()
   },
 
-  observeUserKeymaps() {
-    return new CompositeDisposable(
+  toggleObserveUserKeymaps(enabled) {
+    if (this.userKeymapObserver) this.userKeymapObserver.dispose()
+    if (!enabled) return
+
+    const userKeymapPath = atom.keymaps.getUserKeymapPath()
+    this.userKeymapObserver = new CompositeDisposable(
       atom.keymaps.onDidLoadUserKeymap(() => this.onKeymapLoaded()),
       atom.keymaps.onDidReloadKeymap(({path}) => {
         if (path === userKeymapPath) this.onKeymapLoaded()
@@ -60,6 +31,10 @@ module.exports = {
 
   onConfigChange(commandSpecs) {
     if (this.commandsDisposable) this.commandsDisposable.dispose()
+    for (const commandSpec of commandSpecs) {
+      // Complemente commands prefix.
+      commandSpec.name = "keystroke:" + commandSpec.name
+    }
     this.commandsDisposable = this.registerCommands(commandSpecs)
   },
 
@@ -72,11 +47,8 @@ module.exports = {
     const filePath = atom.keymaps.getUserKeymapPath()
     return atom.keymaps
       .getKeyBindings()
-      .filter(keyBinding => keyBinding.source === filePath && keyBinding.command.startsWith("keystroke:auto:"))
-      .map(({command, selector: scope}) => {
-        const keystroke = command.replace(/^keystroke:auto:/, "")
-        return {name: "auto:" + keystroke, keystroke, scope}
-      })
+      .filter(keyBinding => keyBinding.source === filePath && keyBinding.command.startsWith("keystroke "))
+      .map(({command, selector: scope}) => ({name: command, keystroke: command.replace(/^keystroke /, ""), scope}))
   },
 
   registerCommands(commandSpecs) {
@@ -85,7 +57,7 @@ module.exports = {
       if (!commandsByScope[scope]) {
         commandsByScope[scope] = {}
       }
-      commandsByScope[scope][`keystroke:${name}`] = () => dispatchKeystroke(keystroke)
+      commandsByScope[scope][name] = () => dispatchKeystroke(keystroke)
     }
 
     return new CompositeDisposable(

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,12 @@ const {CompositeDisposable} = require("atom")
 const {dispatchKeystroke} = require("./utils")
 
 const Config = {
+  autoLoadCommandsFromUserKeymap: {
+    type: "boolean",
+    default: true,
+    dscription:
+      "When `true`, each time user-keymap loaded, automatically define the commands starts with `keymaps:auto:`.",
+  },
   commands: {
     type: "array",
     default: [],
@@ -20,29 +26,70 @@ module.exports = {
   config: Config,
 
   activate() {
+    const userKeymapPath = atom.keymaps.getUserKeymapPath()
     this.subscriptions = new CompositeDisposable(
-      atom.config.observe("keystroke.commands", commandSpecs => this.updateCommands(commandSpecs))
+      atom.config.observe("keystroke.commands", commandSpecs => this.registerCommands(commandSpecs)),
+      atom.config.observe("keystroke.autoLoadCommandsFromUserKeymap", enabled => {
+        if (this.userKeymapObserver) this.userKeymapObserver.dispose()
+        if (enabled) this.userKeymapObserver = this.observeUserKeymaps()
+      }),
+      atom.keymaps.onDidLoadUserKeymap(() => this.onKeymapLoaded()),
+      atom.keymaps.onDidReloadKeymap(({path}) => {
+        if (path === userKeymapPath) {
+          this.onKeymapLoaded()
+        }
+      })
     )
   },
 
   deactivate() {
+    if (this.userKeymapObserver) this.userKeymapObserver.dispose()
     if (this.commandsDisposable) this.commandsDisposable.dispose()
+    if (this.autoCommandsDisposable) this.autoCommandsDisposable.dispose()
     this.subscriptions.dispose()
   },
 
-  updateCommands(commandSpecs) {
-    if (this.commandsDisposable) this.commandsDisposable.dispose()
+  observeUserKeymaps() {
+    return new CompositeDisposable(
+      atom.keymaps.onDidLoadUserKeymap(() => this.onKeymapLoaded()),
+      atom.keymaps.onDidReloadKeymap(({path}) => {
+        if (path === userKeymapPath) this.onKeymapLoaded()
+      })
+    )
+  },
 
-    const scopeByCommands = {}
+  onConfigChange(commandSpecs) {
+    if (this.commandsDisposable) this.commandsDisposable.dispose()
+    this.commandsDisposable = this.registerCommands(commandSpecs)
+  },
+
+  onKeymapLoaded() {
+    if (this.autoCommandsDisposable) this.autoCommandsDisposable.dispose()
+    this.autoCommandsDisposable = this.registerCommands(this.buildCommandSpecsFromUserKeymap())
+  },
+
+  buildCommandSpecsFromUserKeymap() {
+    const filePath = atom.keymaps.getUserKeymapPath()
+    return atom.keymaps
+      .getKeyBindings()
+      .filter(keyBinding => keyBinding.source === filePath && keyBinding.command.startsWith("keystroke:auto:"))
+      .map(({command, selector: scope}) => {
+        const keystroke = command.replace(/^keystroke:auto:/, "")
+        return {name: "auto:" + keystroke, keystroke, scope}
+      })
+  },
+
+  registerCommands(commandSpecs) {
+    const commandsByScope = {}
     for (const {name, keystroke, scope = "atom-workspace"} of commandSpecs) {
-      if (!scopeByCommands[scope]) {
-        scopeByCommands[scope] = {}
+      if (!commandsByScope[scope]) {
+        commandsByScope[scope] = {}
       }
-      scopeByCommands[scope][`keystroke:${name}`] = () => dispatchKeystroke(keystroke)
+      commandsByScope[scope][`keystroke:${name}`] = () => dispatchKeystroke(keystroke)
     }
 
-    this.commandsDisposable = new CompositeDisposable(
-      ...Object.keys(scopeByCommands).map(scope => atom.commands.add(scope, scopeByCommands[scope]))
+    return new CompositeDisposable(
+      ...Object.keys(commandsByScope).map(scope => atom.commands.add(scope, commandsByScope[scope]))
     )
   },
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,12 +19,6 @@ function buildKeydownEventFromKeystroke(keystroke, target) {
   return KeymapManager.buildKeydownEvent(key, options)
 }
 
-function keydown(keystroke, target) {
-  const event = buildKeydownEventFromKeystroke(keystroke, target)
-  atom.keymaps.handleKeyboardEvent(event)
-}
-
-// @keymaps.getUserKeymapPath()
 function dispatchKeystroke(keystrokes) {
   const editor = atom.workspace.getActiveTextEditor()
 
@@ -34,8 +28,9 @@ function dispatchKeystroke(keystrokes) {
   atom.keymaps.clearQueuedKeystrokes()
 
   editor.transact(() => {
-    for (const keystroke of normalizeKeystrokes(keystrokes).split(/\s+/)) {
-      keydown(keystroke, document.activeElement)
+    for (const key of normalizeKeystrokes(keystrokes).split(/\s+/)) {
+      const event = buildKeydownEventFromKeystroke(key, document.activeElement)
+      atom.keymaps.handleKeyboardEvent(event)
     }
   })
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,7 @@ function keydown(keystroke, target) {
   atom.keymaps.handleKeyboardEvent(event)
 }
 
+// @keymaps.getUserKeymapPath()
 function dispatchKeystroke(keystrokes) {
   const editor = atom.workspace.getActiveTextEditor()
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,25 @@
   "repository": "https://github.com/t9md/atom-keystroke",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0 <2.0.0"
+    "atom": "^1.19.0"
+  },
+  "configSchema": {
+    "autoLoadCommandsFromUserKeymap": {
+      "type": "boolean",
+      "default": true,
+      "dscription": "When `true`, each time user-keymap loaded, automatically define the commands starts with `keymaps:auto:`."
+    },
+    "commands": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "keystroke": {"type": "string"},
+          "scope": {"type": "string"}
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- When `autoLoadCommandsFromUserKeymap` was `true`
- On user's keymap(`keymap.cson`) was loaded, auto register keystroke commands from loaded user's keybindings.
- Command name used for this purpose must start with `keystroke `(e.g. `keystroke ctrl-p ctrl-p`).

# example

When following `keymap.cson` was saved.

```coffeescript
'atom-text-editor.vim-mode-plus.normal-mode':
  'space 1': 'keystroke 4 k'
```

- Commands `keystroke 4 k` is automatically defined in `atom-text-editor.vim-mode-plus.normal-mode` scope.
- When `keystroke 4 k` was invoked, keystroke `4 k` is executed( emulated ).


# Pros. vs Cons.

- Pros: No indirection, no need to define commands in `config.cson`, all user have to do is edit `keymap.cson`, intuitive.
- Cons: ??
