### PR TITLE
Expose function buildCommandSpecsFromKeyBindings

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -35,9 +35,15 @@ module.exports = {
 
   buildCommandSpecsFromUserKeymap () {
     const filePath = atom.keymaps.getUserKeymapPath()
-    return atom.keymaps
+    return this.buildCommandSpecsFromKeyBindings(atom.keymaps
       .getKeyBindings()
-      .filter(keyBinding => keyBinding.source === filePath && keyBinding.command.startsWith('keystroke '))
+      .filter(keyBinding => keyBinding.source === filePath)
+    );
+  },
+
+  buildCommandSpecsFromKeyBindings (keyBindings) {
+    return keyBindings
+      .filter(keyBinding => keyBinding.command.startsWith('keystroke '))
       .map(({command, selector: scope}) => ({name: command, keystroke: command.replace(/^keystroke /, ''), scope}))
   },
 


### PR DESCRIPTION
- I'm writing a package where I want to use `'keystroke ...'` in my
  keymaps, so I'd like for the package to be able to call
  `buildCommandSpecsFromKeyBindings(...)` on its own keymaps